### PR TITLE
Use Parler's `safe_translation_getter` for service names.

### DIFF
--- a/issues/api/serializers.py
+++ b/issues/api/serializers.py
@@ -70,7 +70,11 @@ class IssueSerializer(serializers.ModelSerializer):
             return None
 
     def get_service_name(self, obj):
-        return obj.service.service_name
+        return obj.service.safe_translation_getter(
+            "service_name",
+            default=obj.service.service_code,
+            any_language=True
+        )
 
     def get_extended_attributes(self, obj):
         extensions = self.context.get('extensions', ())


### PR DESCRIPTION
Sometimes languages just go missing.