### PR TITLE
Simple UI: Bbox coordinate order

### DIFF
--- a/issues_simple_ui/static/issues_simple_ui/browse.js
+++ b/issues_simple_ui/static/issues_simple_ui/browse.js
@@ -123,12 +123,7 @@
 
           map.on('littlePenSelectBox', function (args) {
             state.circle(null);
-            state.bbox([
-              args.bounds.getSouth(),
-              args.bounds.getWest(),
-              args.bounds.getNorth(),
-              args.bounds.getEast(),
-            ].join(','));
+            state.bbox(args.bounds.toBBoxString());
           });
           map.on('littlePenSelectCircle', function (args) {
             state.bbox(null);


### PR DESCRIPTION
Make the simple UI pass bbox coordinates in the OSM order (as changed in 8846578)

Fixes #56